### PR TITLE
Cleanup and fixes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,8 @@ Changelog
 
 - Handled tabs navigation preventing going out of the modal [nzambello]
 - Added close button to avoid mockup modal close button issues [nzambello]
+- Added uninstall profiles [pnicolli]
+- Loading resources bundle only when showing our custom view [pnicolli]
 
 
 0.1.3 (2017-10-13)

--- a/src/redturtle/gallery/browser/configure.zcml
+++ b/src/redturtle/gallery/browser/configure.zcml
@@ -39,7 +39,7 @@
 
   <include package="plone.app.contentmenu" />
   <browser:menuItems
-      for="plone.app.blocks.layoutbehavior.ILayoutBehaviorAdaptable"
+      for="plone.app.contenttypes.interfaces.IFolder"
       menu="plone_displayviews">
     <browser:menuItem
         title="Gallery view"

--- a/src/redturtle/gallery/browser/gallery.py
+++ b/src/redturtle/gallery/browser/gallery.py
@@ -1,4 +1,5 @@
 from plone.app.contenttypes.browser.folder import FolderView
+from Products.CMFPlone.resources import add_bundle_on_request
 from Products.Five.browser import BrowserView
 
 
@@ -6,6 +7,9 @@ class GalleryView(FolderView, BrowserView):
     """
     Gallery view
     """
+    def __call__(self):
+        add_bundle_on_request(self.request, 'redturtle-gallery-bundle')
+        return super(GalleryView, self).__call__()
 
 
 class GalleryModal(BrowserView):

--- a/src/redturtle/gallery/profiles/default/registry.xml
+++ b/src/redturtle/gallery/profiles/default/registry.xml
@@ -12,7 +12,7 @@
   <!-- BUNDLE -->
   <records prefix="plone.bundles/redturtle-gallery-bundle"
            interface='Products.CMFPlone.interfaces.IBundleRegistry'>
-    <value key="enabled">True</value>
+    <value key="enabled">False</value>
     <value key="resources" purge="false">
       <element>redturtle-gallery</element>
     </value>

--- a/src/redturtle/gallery/profiles/uninstall/registry.xml
+++ b/src/redturtle/gallery/profiles/uninstall/registry.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+<registry>
+
+  <!-- RESOURCE -->
+  <records prefix="plone.resources/redturtle-gallery"
+           interface='Products.CMFPlone.interfaces.IResourceRegistry'
+           remove="True" />
+
+  <!-- BUNDLE -->
+  <records prefix="plone.bundles/redturtle-gallery-bundle"
+           interface='Products.CMFPlone.interfaces.IBundleRegistry'
+           remove="True" />
+
+</registry>

--- a/src/redturtle/gallery/profiles/uninstall/types/Folder.xml
+++ b/src/redturtle/gallery/profiles/uninstall/types/Folder.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+<object
+    i18n:domain="plone"
+    meta_type="Dexterity FTI"
+    name="Folder"
+    xmlns:i18n="http://xml.zope.org/namespaces/i18n">
+
+  <property
+      name="view_methods"
+      purge="false">
+    <element value="gallery_view" remove="True" />
+  </property>
+
+</object>


### PR DESCRIPTION
Several minor fixes:

- Now loading resources bundle only when showing our custom view
- Added uninstall profiles: now removing resources and custom view when the addon is uninstalled
- Changed custom view availability to all Folders (instead of depending on the plone.app.blocks interface, which looks unneeded, please tell me what I missed otherwise)